### PR TITLE
Fix Jest SCSS error

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -66,5 +66,11 @@
     "webpack": "^5.30.0",
     "webpack-cli": "^4.6.0",
     "webpack-dev-server": "^3.11.2"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css|scss)$": "<rootDir>/__mocks__/fileMock.js"
+    }
   }
 }


### PR DESCRIPTION
Add jest config in package.json
Add __mocks__ folder to hold empty jest exports
Add styleMock.js and fileMock.js for compatibility

See: https://jestjs.io/docs/webpack